### PR TITLE
Stop bailing when no docker-compose found

### DIFF
--- a/main.go
+++ b/main.go
@@ -287,8 +287,8 @@ func setup() {
 
 	dockerComposeCmd, err = exec.LookPath("docker-compose")
 	if err != nil {
-		log.Errorf("Could not find docker-compose command: %v", err)
-		os.Exit(1)
+		log.Warnf("Could not find docker-compose command: %v", err)
+		log.Warn("docker-compose builds will not work")
 	}
 
 	cmd := exec.Command(dockerCmd, "info")


### PR DESCRIPTION
It doesn't work from a docker container anyway so I stopped installing it in there. But that means we shouldn't bail if it isn't found.

This will hopefully help fix our CI builds.