### PR TITLE
Fix server waits and image pulls

### DIFF
--- a/main.go
+++ b/main.go
@@ -231,10 +231,6 @@ func runSingle(tester *containerConfig, tupelo *containerConfig) int {
 				pullImage(tupelo.Image)
 			}
 
-			if tester.Build == "" {
-				pullImage(tester.Image)
-			}
-
 			fmt.Println("Starting tupelo container")
 			containerID, cancel, err := dockerRunDaemon(tupelo)
 			if err != nil {
@@ -273,6 +269,10 @@ func runSingle(tester *containerConfig, tupelo *containerConfig) int {
 	tester.Env["TUPELO_VERSION"] = version
 	if runningTupelo["network"] != "" {
 		tester.Network = runningTupelo["network"]
+	}
+
+	if tester.Build == "" {
+		pullImage(tester.Image)
 	}
 
 	err = dockerRunForeground(tester)

--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ func dockerRunForeground(cfg *containerConfig) error {
 }
 
 func dockerPull(image string) error {
+	fmt.Println("Pulling image", image)
 	_, err := runCmd(dockerCmd, "pull", image)
 	if err != nil {
 		return err


### PR DESCRIPTION
This ended up _slightly_ in overkill territory because I have a hard time keeping straight what's running where, when (Docker vs. host) with all this, haha.

The main problem this is solving is that when tupelo-integration-runner is running on the host, it needs to look for the bootstrap and RPC servers on `127.0.0.1` (forwarded from the docker-compose stack) but when it's running in Docker it needs to look for them on the same IP that the other containers will connect to (i.e. the `tupelo_default` Docker network one). And we do both in different repos. But either way the other containers only ever use the `tupelo_default` IP to make the connection b/c they're always running in Docker. Confusing.

And then I also noticed that we weren't pulling tester images every time, which we definitely should b/c we're using mutable tags like `latest` and `master` for them.

Anyway, short of a larger rethink of all this, I think we're getting to close to something that will get us running more integration tests a lot more often.